### PR TITLE
Remove ROOT module support

### DIFF
--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPlugin.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPlugin.java
@@ -18,13 +18,13 @@ import org.jqassistant.contrib.plugin.hcl.model.TerraformOutputVariable;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformProvider;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformProviderResource;
 import org.jqassistant.contrib.plugin.hcl.parser.ASTParser;
+import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.Configuration;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.InputVariable;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.LogicalModule;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.Module;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.OutputVariable;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.Provider;
 import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.ProviderResource;
-import org.jqassistant.contrib.plugin.hcl.parser.model.terraform.Configuration;
 import org.jqassistant.contrib.plugin.hcl.util.StoreHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,8 +137,8 @@ public class TerraformScannerPlugin extends AbstractScannerPlugin<FileResource, 
       ast.terraform().forEach(terraformContext -> {
         final Configuration configuration = astParser.extractConfiguration(terraformContext);
         final TerraformConfiguration terraformConfiguration = configuration.toStore(storeHelper,
-            Configuration.calculateFullQualifiedName(Paths.get(path)), Paths.get(path).getParent(), currentLogicalModule,
-            TerraformConfiguration.class);
+            Configuration.calculateFullQualifiedName(Paths.get(path)), Paths.get(path).getParent(),
+            currentLogicalModule, TerraformConfiguration.class);
 
         currentLogicalModule.getConfiguration().add(terraformConfiguration);
       });
@@ -152,5 +152,4 @@ public class TerraformScannerPlugin extends AbstractScannerPlugin<FileResource, 
 
     return terraformFileDescriptor;
   }
-
 }

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/model/TerraformLogicalModule.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/model/TerraformLogicalModule.java
@@ -31,7 +31,7 @@ public interface TerraformLogicalModule extends TerraformBlock {
   @Relation("CALLS")
   List<TerraformModule> getCalledModules();
 
-  @Relation("CONFIGURE_TERRAFORM_WITH")
+  @Relation("CONFIGURES_TERRAFORM_WITH")
   List<TerraformConfiguration> getConfiguration();
 
   @Relation("DECLARES_INPUT_VARIABLE")

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/LogicalModule.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/LogicalModule.java
@@ -2,7 +2,6 @@ package org.jqassistant.contrib.plugin.hcl.parser.model.terraform;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jqassistant.contrib.plugin.hcl.model.TerraformDescriptor;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformLogicalModule;
@@ -19,15 +18,13 @@ import com.google.common.collect.ImmutableMap;
  */
 public class LogicalModule extends TerraformObject<TerraformLogicalModule> {
   /**
-   * Calculates the full qualified name for an logical module.
+   * Calculates the full qualified name for a logical module.
    *
    * @param directory the path name of the file this module is defined in
    * @return A name which can be used as ID
    */
   public static String calculateFullQualifiedName(final Path directory) {
-    final Path pathName = directory.normalize().getParent();
-
-    return pathName.equals(Paths.get(File.separator)) ? "ROOT" : pathName.toString().replace(File.separatorChar, '.');
+    return directory.normalize().getParent().toString().replace(File.separatorChar, '.');
   }
 
   private final String name;


### PR DESCRIPTION
It is not possible to identify the ROOT module during scanning as we do not know which files are scanned. Thus the ROOT module can only be marked with a concept.