### PR TITLE
Add concept for RootModule

### DIFF
--- a/src/main/resources/META-INF/jqassistant-rules/hcl.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/hcl.xml
@@ -1,0 +1,18 @@
+<jqa:jqassistant-rules
+	xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.0">
+
+	<concept id="hcl:RootModule">
+		<description>Determines the root module (the start, top level module) and labels it as RootModule.
+		</description>
+		<cypher><![CDATA[
+            MATCH (n:Terraform:LogicalModule) 
+            
+            WITH n 
+            ORDER BY size(n.fullQualifiedName) ASC LIMIT 1
+            
+            SET n:RootModule
+            
+            RETURN n
+        ]]></cypher>
+	</concept>
+</jqa:jqassistant-rules>


### PR DESCRIPTION
The RootModule is the entry point for Terraform, the top level module. This concept marks the top level module with the label RootModule. Especially useful to analze the graph.