### PR TITLE
Link depends_on objects to correct descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>3.6.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
@@ -82,7 +82,7 @@ public class Module extends TerraformObject<TerraformModule> {
       final String dependentFullQualifiedObjectName = partOfModule.getFullQualifiedName() + "." + dependentObjectName;
 
       final TerraformBlock block = storeHelper.createOrRetrieveObject(
-          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentObjectName), partOfModule,
+          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName), partOfModule,
           TerraformBlock.class);
       block.setFullQualifiedName(dependentFullQualifiedObjectName);
 

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
@@ -82,7 +82,7 @@ public class Module extends TerraformObject<TerraformModule> {
       final String dependentFullQualifiedObjectName = partOfModule.getFullQualifiedName() + "." + dependentObjectName;
 
       final TerraformBlock block = storeHelper.createOrRetrieveObject(
-          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName), partOfModule,
+          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName),
           TerraformBlock.class);
       block.setFullQualifiedName(dependentFullQualifiedObjectName);
 
@@ -95,7 +95,7 @@ public class Module extends TerraformObject<TerraformModule> {
           .calculateFullQualifiedName(Paths.get(moduleSource));
 
       final TerraformLogicalModule referencedModule = storeHelper.createOrRetrieveObject(
-          ImmutableMap.of(TerraformDescriptor.FieldName.FULL_QUALIFIED_NAME, fullQualifiedNameOfReferencedModule), null,
+          ImmutableMap.of(TerraformDescriptor.FieldName.FULL_QUALIFIED_NAME, fullQualifiedNameOfReferencedModule),
           TerraformLogicalModule.class);
       referencedModule.setFullQualifiedName(fullQualifiedNameOfReferencedModule);
 

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/Module.java
@@ -79,10 +79,12 @@ public class Module extends TerraformObject<TerraformModule> {
     object.setVersion(this.version);
 
     this.dependantResources.forEach(dependentObjectName -> {
+      final String dependentFullQualifiedObjectName = partOfModule.getFullQualifiedName() + "." + dependentObjectName;
+
       final TerraformBlock block = storeHelper.createOrRetrieveObject(
           ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentObjectName), partOfModule,
           TerraformBlock.class);
-      block.setFullQualifiedName(dependentObjectName);
+      block.setFullQualifiedName(dependentFullQualifiedObjectName);
 
       object.getDependantResources().add(block);
     });

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/OutputVariable.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/OutputVariable.java
@@ -52,11 +52,12 @@ public class OutputVariable extends TerraformObject<TerraformOutputVariable> {
     object.setInternalName(this.name);
 
     this.dependentObjects.forEach(dependentObjectName -> {
+      final String dependentFullQualifiedObjectName = partOfModule.getFullQualifiedName() + "." + dependentObjectName;
+
       final TerraformBlock block = storeHelper.createOrRetrieveObject(
-          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME,
-              TerraformObject.getFullQualifiedNamePrefix(filePath) + dependentObjectName),
-          partOfModule, TerraformBlock.class);
-      block.setFullQualifiedName(dependentObjectName);
+          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName), partOfModule,
+          TerraformBlock.class);
+      block.setFullQualifiedName(dependentFullQualifiedObjectName);
 
       object.getDependantObjects().add(block);
     });

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/OutputVariable.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/OutputVariable.java
@@ -55,7 +55,7 @@ public class OutputVariable extends TerraformObject<TerraformOutputVariable> {
       final String dependentFullQualifiedObjectName = partOfModule.getFullQualifiedName() + "." + dependentObjectName;
 
       final TerraformBlock block = storeHelper.createOrRetrieveObject(
-          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName), partOfModule,
+          ImmutableMap.of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, dependentFullQualifiedObjectName),
           TerraformBlock.class);
       block.setFullQualifiedName(dependentFullQualifiedObjectName);
 

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/TerraformObject.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/parser/model/terraform/TerraformObject.java
@@ -60,7 +60,7 @@ public abstract class TerraformObject<T extends TerraformBlock> {
   public T toStore(final StoreHelper storeHelper, final String fullQualifiedName, final Path filePath,
       final TerraformLogicalModule partOfModule, final Class<T> clazz) {
     final T object = storeHelper.createOrRetrieveObject(
-        ImmutableMap.of(TerraformDescriptor.FieldName.FULL_QUALIFIED_NAME, fullQualifiedName), partOfModule, clazz);
+        ImmutableMap.of(TerraformDescriptor.FieldName.FULL_QUALIFIED_NAME, fullQualifiedName), clazz);
 
     return saveInternalState(object, partOfModule, filePath, storeHelper);
   }

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelper.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelper.java
@@ -1,6 +1,7 @@
 package org.jqassistant.contrib.plugin.hcl.util;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.jqassistant.contrib.plugin.hcl.model.TerraformBlock;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformDescriptor;
@@ -99,23 +100,39 @@ public class StoreHelper {
     logger.trace("Query database for object: {}, {}", clazz.getSimpleName(), searchCriteria);
 
     if (partOfModule == null) {
-      final String query = String.format("match (n:Terraform %s) where n:%s return n", fieldClause, label);
+      final String query = String.format("match (n:Terraform %s) where (n:%s or n:Block) return n", fieldClause, label);
       logger.trace(query);
       storeResult = this.store.executeQuery(query);
     } else {
-      final String query = String.format("match (n:Terraform %s)-[*]-(m:LogicalModule {%s: '%s'}) where n:%s return n",
-          fieldClause, TerraformLogicalModule.FieldName.FULL_QUALIFIED_NAME.getModelName(),
-          partOfModule.getFullQualifiedName(), label);
+      final String query = String.format("match (n:Terraform %s) where (n:%s or n:Block) return n", fieldClause, label);
       logger.trace(query);
       storeResult = this.store.executeQuery(query);
     }
 
+    T objectInStore;
+
     if (storeResult.hasResult()) {
       logger.debug("Object found in database");
-      return storeResult.getSingleResult().get("n", clazz);
+      objectInStore = (T) storeResult.getSingleResult().get("n", TerraformBlock.class);
     } else {
       logger.debug("Creating a new object in the database");
-      return this.store.create(clazz);
+      objectInStore = this.store.create(clazz);
     }
+
+    // TODO rework please. Looks ugly
+    final boolean blockNeedsConversion = !clazz.equals(TerraformBlock.class)
+        && Stream.of(objectInStore.getClass().getAnnotatedInterfaces())
+            .anyMatch(p -> p.getType().getTypeName().equals(TerraformBlock.class.getTypeName()));
+
+    if (blockNeedsConversion) {
+      // we read a TerraformBlock. This might happen when we did not know the correct
+      // type at time of creation. We correct the descriptor now
+      objectInStore = this.store.addDescriptorType(objectInStore, clazz);
+    }
+
+    final String fullQualifiedName = searchCriteria.get(TerraformDescriptor.FieldName.FULL_QUALIFIED_NAME);
+    objectInStore.setFullQualifiedName(fullQualifiedName);
+
+    return objectInStore.as(clazz);
   }
 }

--- a/src/test/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPluginModuleIT.java
+++ b/src/test/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPluginModuleIT.java
@@ -67,7 +67,7 @@ public class TerraformScannerPluginModuleIT extends AbstractTerraformPluginIT {
     final List<TerraformBlock> actualDependantObjects = actualModule.getDependantResources();
 
     assertThat(actualDependantObjects).hasSize(1).extracting(TerraformBlock::getFullQualifiedName)
-        .containsExactlyInAnyOrder("aws_db_instance.main");
+        .containsExactlyInAnyOrder(".terraform.module.aws_db_instance.main");
 
     // read all properties as some are not part of the model (input parameters)
     final Map<String, String> actualProperties = this.readAllProperties(actualModule);

--- a/src/test/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPluginOutputVariableIT.java
+++ b/src/test/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPluginOutputVariableIT.java
@@ -40,7 +40,8 @@ public class TerraformScannerPluginOutputVariableIT extends AbstractPluginIT {
         .getDependantObjects();
 
     assertThat(actualDependantObjects).hasSize(2).extracting(TerraformBlock::getFullQualifiedName)
-        .containsExactlyInAnyOrder("aws_db_instance.db", "aws_db_instance.db_new");
+        .containsExactlyInAnyOrder(".terraform.output variable.aws_db_instance.db",
+            ".terraform.output variable.aws_db_instance.db_new");
   }
 
   @BeforeEach

--- a/src/test/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelperUnitIT.java
+++ b/src/test/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelperUnitIT.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
+import org.jqassistant.contrib.plugin.hcl.model.TerraformBlock;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformLogicalModule;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformModelField;
+import org.jqassistant.contrib.plugin.hcl.model.TerraformProviderResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,5 +38,41 @@ public class StoreHelperUnitIT extends AbstractPluginIT {
 
     // then
     assertThat(actualCreated.getFullQualifiedName()).isEqualTo(actualFound.getFullQualifiedName());
+  }
+
+  @Test
+  public void shouldReturnTheSpecializedDescriptor_whenCreateOrRetrieveObject_givenObjectWithFullQualifiedNameExistsAsTerraformBlock() {
+    // given
+    final Map<TerraformModelField, String> givenSearchCriteria = ImmutableMap
+        .of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, "XXX");
+
+    // when
+    final StoreHelper s = new StoreHelper(this.store);
+
+    final TerraformBlock actualCreated = s.createOrRetrieveObject(givenSearchCriteria, TerraformBlock.class);
+
+    final TerraformProviderResource actualConverted = s.createOrRetrieveObject(givenSearchCriteria,
+        TerraformProviderResource.class);
+
+    // then
+    final Object idCreated = actualCreated.getId();
+    final Object idConverted = actualConverted.getId();
+
+    assertThat(idCreated).isEqualTo(idConverted);
+  }
+
+  @Test
+  public void shouldSetTheFullQualifiedName_whenCreateOrRetrieveObject() {
+    // given
+    final Map<TerraformModelField, String> givenSearchCriteria = ImmutableMap
+        .of(TerraformBlock.FieldName.FULL_QUALIFIED_NAME, "XXX");
+
+    // when
+    final StoreHelper s = new StoreHelper(this.store);
+
+    final TerraformBlock actualCreated = s.createOrRetrieveObject(givenSearchCriteria, TerraformBlock.class);
+
+    // then
+    assertThat(actualCreated.getFullQualifiedName()).isEqualTo("XXX");
   }
 }

--- a/src/test/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelperUnitTest.java
+++ b/src/test/java/org/jqassistant/contrib/plugin/hcl/util/StoreHelperUnitTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.jqassistant.contrib.plugin.hcl.model.TerraformBlock;
 import org.jqassistant.contrib.plugin.hcl.model.TerraformDescriptor;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,21 +38,14 @@ public class StoreHelperUnitTest {
 
   }
 
-  private AutoCloseable closeableMocks;
-
   private StoreHelper storeHelper;
 
   @Mock
   private Store stubbedStore;
 
-  @AfterEach
-  public void closeMocks() throws Exception {
-    this.closeableMocks.close();
-  }
-
   @BeforeEach
   public void initClassUnderTest() {
-    this.closeableMocks = MockitoAnnotations.openMocks(this);
+    MockitoAnnotations.initMocks(this);
 
     this.storeHelper = new StoreHelper(this.stubbedStore);
   }


### PR DESCRIPTION
The full qualified name was calculated incorrectly. Thus a new descriptor was created instead of using the one already present. This resulted in a wrong model of the terraform file.