### PR TITLE
Use a default name for the root module if automatic naming is not working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -194,7 +193,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPlugin.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/hcl/TerraformScannerPlugin.java
@@ -44,139 +44,144 @@ import com.buschmais.jqassistant.plugin.common.api.scanner.filesystem.FileResour
 
 @ScannerPlugin.Requires(FileDescriptor.class)
 public class TerraformScannerPlugin extends AbstractScannerPlugin<FileResource, TerraformFileDescriptor> {
-  private static final Logger logger = LoggerFactory.getLogger(TerraformScannerPlugin.class);
+    private static final String DEFAULT_ROOT_MODULE_NAME = "ROOT";
+    private static final Logger logger = LoggerFactory.getLogger(TerraformScannerPlugin.class);
 
-  @Override
-  public boolean accepts(final FileResource item, final String path, final Scope scope) throws IOException {
-    return path.toLowerCase().endsWith(".tf");
-  }
-
-  @Override
-  public TerraformFileDescriptor scan(final FileResource item, final String path, final Scope scope,
-      final Scanner scanner) {
-    final ScannerContext context = scanner.getContext();
-    final Store store = context.getStore();
-
-    // add the file
-    final FileDescriptor fileDescriptor = context.getCurrentDescriptor();
-    final TerraformFileDescriptor terraformFileDescriptor = store.addDescriptorType(fileDescriptor,
-        TerraformFileDescriptor.class);
-    try {
-      logger.trace("File: {}", item.getFile().getAbsolutePath());
-
-      final terraformLexer lexer = new terraformLexer(CharStreams.fromStream(item.createStream()));
-      final CommonTokenStream tokens = new CommonTokenStream(lexer);
-      final terraformParser parser = new terraformParser(tokens);
-
-      final FileContext ast = parser.file();
-
-      final ASTParser astParser = new ASTParser();
-      final StoreHelper storeHelper = new StoreHelper(store);
-
-      terraformFileDescriptor.setInternalName(item.getFile().getName());
-      terraformFileDescriptor.setName(terraformFileDescriptor.getInternalName());
-
-      final Path moduleDirectory = Paths.get(path).getParent();
-      final String logicalModuleName = moduleDirectory.getName(moduleDirectory.getNameCount() - 1).toString();
-
-      // as this object does not exist in terraform, it can't be extracted from the
-      // AST
-      final TerraformLogicalModule currentLogicalModule = new LogicalModule(logicalModuleName).toStore(storeHelper,
-          LogicalModule.calculateFullQualifiedName(Paths.get(path).getParent()), Paths.get(path), null,
-          TerraformLogicalModule.class);
-
-      terraformFileDescriptor.setModule(currentLogicalModule);
-
-      ast.variable().forEach(inputVariableContext -> {
-        final InputVariable inputVariable = astParser.extractInputVariable(inputVariableContext);
-
-        final TerraformInputVariable terraformInputVariable = inputVariable.toStore(storeHelper,
-            InputVariable.calculateFullQualifiedName(inputVariable.getName(), Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformInputVariable.class);
-
-        terraformFileDescriptor.getBlocks().add(terraformInputVariable);
-        currentLogicalModule.getInputVariables().add(terraformInputVariable);
-      });
-
-      ast.output().forEach(outputVariableContext -> {
-        final OutputVariable outputVariable = astParser.extractOutputVariable(outputVariableContext);
-
-        final TerraformOutputVariable terraFormOutputVariable = outputVariable.toStore(storeHelper,
-            OutputVariable.calculateFullQualifiedName(outputVariable.getName(), Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformOutputVariable.class);
-
-        terraformFileDescriptor.getBlocks().add(terraFormOutputVariable);
-        currentLogicalModule.getOutputVariables().add(terraFormOutputVariable);
-      });
-
-      ast.local().forEach(localVariableContext -> {
-        final LocalVariable localVariable = astParser.extractLocalVariable(localVariableContext);
-
-        final TerraformLocalVariable terraformLocalVariable = localVariable.toStore(storeHelper,
-            LocalVariable.calculateFullQualifiedName(localVariable.getName(), Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformLocalVariable.class);
-
-        terraformFileDescriptor.getBlocks().add(terraformLocalVariable);
-        currentLogicalModule.getLocalVariables().add(terraformLocalVariable);
-      });
-
-      ast.module().forEach(moduleContext -> {
-        final Module moduleCall = astParser.extractModuleCall(moduleContext);
-
-        final TerraformModule terraFormModule = moduleCall.toStore(storeHelper,
-            Module.calculateFullQualifiedName(moduleCall.getSource(), moduleCall.getName(), Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformModule.class);
-
-        currentLogicalModule.getCalledModules().add(terraFormModule);
-      });
-
-      ast.provider().forEach(providerContext -> {
-        final Provider provider = astParser.extractProvider(providerContext);
-
-        final TerraformProvider terraformProvider = provider.toStore(storeHelper,
-            Provider.calculateFullQualifiedName(provider.getName(), Paths.get(path)), Paths.get(path).getParent(),
-            currentLogicalModule, TerraformProvider.class);
-
-        currentLogicalModule.getProviders().add(terraformProvider);
-      });
-
-      ast.resource().forEach(cloudResourceContext -> {
-        final ProviderResource providerResource = astParser.extractProviderResource(cloudResourceContext);
-        final TerraformProviderResource terraformProviderResource = providerResource.toStore(
-            storeHelper, ProviderResource.calculateFullQualifiedName(providerResource.getName(),
-                providerResource.getType(), Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformProviderResource.class);
-
-        currentLogicalModule.getProviderResources().add(terraformProviderResource);
-      });
-
-      ast.data().forEach(providerDataResourceContext -> {
-        final ProviderDataResource providerDataResource = astParser
-            .extractProviderDataResource(providerDataResourceContext);
-        final TerraformProviderDataResource terraformProviderDataResource = providerDataResource.toStore(storeHelper,
-            ProviderResource.calculateFullQualifiedName(providerDataResource.getName(), providerDataResource.getType(),
-                Paths.get(path)),
-            Paths.get(path).getParent(), currentLogicalModule, TerraformProviderDataResource.class);
-
-        currentLogicalModule.getProviderDataResources().add(terraformProviderDataResource);
-      });
-
-      ast.terraform().forEach(terraformContext -> {
-        final Configuration configuration = astParser.extractConfiguration(terraformContext);
-        final TerraformConfiguration terraformConfiguration = configuration.toStore(storeHelper,
-            Configuration.calculateFullQualifiedName(Paths.get(path)), Paths.get(path).getParent(),
-            currentLogicalModule, TerraformConfiguration.class);
-
-        currentLogicalModule.getConfiguration().add(terraformConfiguration);
-      });
-
-      terraformFileDescriptor.setValid(true);
-    } catch (final IOException e) {
-      terraformFileDescriptor.setValid(false);
-
-      logger.error(String.format("Error reading file {}", path), e);
+    @Override
+    public boolean accepts(final FileResource item, final String path, final Scope scope) throws IOException {
+        return path.toLowerCase().endsWith(".tf");
     }
 
-    return terraformFileDescriptor;
-  }
+    @Override
+    public TerraformFileDescriptor scan(final FileResource item, final String path, final Scope scope,
+            final Scanner scanner) {
+        final ScannerContext context = scanner.getContext();
+        final Store store = context.getStore();
+
+        // add the file
+        final FileDescriptor fileDescriptor = context.getCurrentDescriptor();
+        final TerraformFileDescriptor terraformFileDescriptor = store.addDescriptorType(fileDescriptor,
+                TerraformFileDescriptor.class);
+        try {
+            logger.trace("File: {}", item.getFile().getAbsolutePath());
+
+            final terraformLexer lexer = new terraformLexer(CharStreams.fromStream(item.createStream()));
+            final CommonTokenStream tokens = new CommonTokenStream(lexer);
+            final terraformParser parser = new terraformParser(tokens);
+
+            final FileContext ast = parser.file();
+
+            final ASTParser astParser = new ASTParser();
+            final StoreHelper storeHelper = new StoreHelper(store);
+
+            terraformFileDescriptor.setInternalName(item.getFile().getName());
+            terraformFileDescriptor.setName(terraformFileDescriptor.getInternalName());
+
+            final Path moduleDirectory = Paths.get(path).getParent();
+            final String logicalModuleName = moduleDirectory.getNameCount() > 0
+                    ? moduleDirectory.getName(moduleDirectory.getNameCount() - 1).toString()
+                    : DEFAULT_ROOT_MODULE_NAME;
+
+            // as this object does not exist in terraform, it can't be extracted from the
+            // AST
+            final TerraformLogicalModule currentLogicalModule = new LogicalModule(logicalModuleName).toStore(
+                    storeHelper, LogicalModule.calculateFullQualifiedName(Paths.get(path).getParent()), Paths.get(path),
+                    null, TerraformLogicalModule.class);
+
+            terraformFileDescriptor.setModule(currentLogicalModule);
+
+            ast.variable().forEach(inputVariableContext -> {
+                final InputVariable inputVariable = astParser.extractInputVariable(inputVariableContext);
+
+                final TerraformInputVariable terraformInputVariable = inputVariable.toStore(storeHelper,
+                        InputVariable.calculateFullQualifiedName(inputVariable.getName(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformInputVariable.class);
+
+                terraformFileDescriptor.getBlocks().add(terraformInputVariable);
+                currentLogicalModule.getInputVariables().add(terraformInputVariable);
+            });
+
+            ast.output().forEach(outputVariableContext -> {
+                final OutputVariable outputVariable = astParser.extractOutputVariable(outputVariableContext);
+
+                final TerraformOutputVariable terraFormOutputVariable = outputVariable.toStore(storeHelper,
+                        OutputVariable.calculateFullQualifiedName(outputVariable.getName(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformOutputVariable.class);
+
+                terraformFileDescriptor.getBlocks().add(terraFormOutputVariable);
+                currentLogicalModule.getOutputVariables().add(terraFormOutputVariable);
+            });
+
+            ast.local().forEach(localVariableContext -> {
+                final LocalVariable localVariable = astParser.extractLocalVariable(localVariableContext);
+
+                final TerraformLocalVariable terraformLocalVariable = localVariable.toStore(storeHelper,
+                        LocalVariable.calculateFullQualifiedName(localVariable.getName(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformLocalVariable.class);
+
+                terraformFileDescriptor.getBlocks().add(terraformLocalVariable);
+                currentLogicalModule.getLocalVariables().add(terraformLocalVariable);
+            });
+
+            ast.module().forEach(moduleContext -> {
+                final Module moduleCall = astParser.extractModuleCall(moduleContext);
+
+                final TerraformModule terraFormModule = moduleCall.toStore(storeHelper,
+                        Module.calculateFullQualifiedName(moduleCall.getSource(), moduleCall.getName(),
+                                Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformModule.class);
+
+                currentLogicalModule.getCalledModules().add(terraFormModule);
+            });
+
+            ast.provider().forEach(providerContext -> {
+                final Provider provider = astParser.extractProvider(providerContext);
+
+                final TerraformProvider terraformProvider = provider.toStore(storeHelper,
+                        Provider.calculateFullQualifiedName(provider.getName(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformProvider.class);
+
+                currentLogicalModule.getProviders().add(terraformProvider);
+            });
+
+            ast.resource().forEach(cloudResourceContext -> {
+                final ProviderResource providerResource = astParser.extractProviderResource(cloudResourceContext);
+                final TerraformProviderResource terraformProviderResource = providerResource.toStore(storeHelper,
+                        ProviderResource.calculateFullQualifiedName(providerResource.getName(),
+                                providerResource.getType(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformProviderResource.class);
+
+                currentLogicalModule.getProviderResources().add(terraformProviderResource);
+            });
+
+            ast.data().forEach(providerDataResourceContext -> {
+                final ProviderDataResource providerDataResource = astParser
+                        .extractProviderDataResource(providerDataResourceContext);
+                final TerraformProviderDataResource terraformProviderDataResource = providerDataResource.toStore(
+                        storeHelper,
+                        ProviderResource.calculateFullQualifiedName(providerDataResource.getName(),
+                                providerDataResource.getType(), Paths.get(path)),
+                        Paths.get(path).getParent(), currentLogicalModule, TerraformProviderDataResource.class);
+
+                currentLogicalModule.getProviderDataResources().add(terraformProviderDataResource);
+            });
+
+            ast.terraform().forEach(terraformContext -> {
+                final Configuration configuration = astParser.extractConfiguration(terraformContext);
+                final TerraformConfiguration terraformConfiguration = configuration.toStore(storeHelper,
+                        Configuration.calculateFullQualifiedName(Paths.get(path)), Paths.get(path).getParent(),
+                        currentLogicalModule, TerraformConfiguration.class);
+
+                currentLogicalModule.getConfiguration().add(terraformConfiguration);
+            });
+
+            terraformFileDescriptor.setValid(true);
+        } catch (final IOException e) {
+            terraformFileDescriptor.setValid(false);
+
+            logger.error(String.format("Error reading file {}", path), e);
+        }
+
+        return terraformFileDescriptor;
+    }
 }


### PR DESCRIPTION
The automatic naming strategy is based on the name of the parent directory. If there is none "ROOT" will be used as name.